### PR TITLE
Fix Jekyll config indentation for build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ description: |
   <br><br><br><br><br>
   <span class="contact-header">контакты</span>
   <br><br>
-<img src="email.png" alt="email" style="width:200px;margin-top:6px;">
+  <img src="email.png" alt="email" style="width:200px;margin-top:6px;">
   <br>
   <img src="qr.png" alt="Telegram QR" style="width:200px;">
 theme: jekyll-theme-minimal


### PR DESCRIPTION
## Summary
- indent email and QR image entries in Jekyll `_config.yml`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689510a08dfc83279e7f373e7422dad6