### PR TITLE
Style contact section and resize media

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,11 +1,11 @@
 title: Айдар Алиев - Data Engineer
 description: |
-  <img src="photo.jpg" alt="Айдар Алиев" class="profile-photo" style="border-radius:8px;">
-  <br><br><br><br><br>
-  <span class="contact-header">контакты</span>
-  <br><br>
-<img src="email.png" alt="email" style="width:200px;margin-top:6px;">
+  <img src="photo.jpg" alt="Айдар Алиев" class="profile-photo" style="border-radius:8px;width:350px;">
   <br>
-  <img src="qr.png" alt="Telegram QR" style="width:200px;">
+  <h2 class="contact-header">контакты</h2>
+  <br><br>
+  <img src="email.png" alt="email" style="width:270px;margin-top:6px;">
+  <br>
+  <img src="qr.png" alt="Telegram QR" style="width:350px;height:auto;">
 theme: jekyll-theme-minimal
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ a:hover, summary:hover{ text-decoration:underline; }
 header p.view, header small, footer, .view, small{display:none!important;}
 a, summary{ color:var(--gold)!important; }
 a:hover, summary:hover{ text-decoration:underline; }
+.contact-header{ color:var(--gold); font-size:180%; margin-top:0; }
 </style>
 
 


### PR DESCRIPTION
## Summary
- shrink spacing around profile photo and promote `контакты` to gold header
- enlarge email icon and size QR code to match profile photo width

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689510a08dfc83279e7f373e7422dad6