### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -149,3 +149,12 @@ details.collapsible-details[open] > summary::before{transform:rotate(90deg); col
   width:auto !important;
   max-width:220px !important;
 }
+
+/* Responsive layout adjustments for narrow viewports */
+@media (max-width: 768px){
+  .container{flex-direction:column;gap:24px;padding:16px;}
+  .sidebar{position:static;height:auto;width:100%;max-width:none;}
+  .sidebar-left,.sidebar-right{min-width:0;max-width:none;}
+  .content{max-width:none;}
+  .sidebar-right{order:3;}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,4 +196,3 @@ title: Айдар Алиев – Data Engineer
     <li>Открыт к предложениям Data Engineer, ML Engineer и Data Analyst.</li>
   </ul>
 </details>
-


### PR DESCRIPTION
## Summary
- stack sidebars vertically on narrow screens to keep main content readable
- fix markdown lint issue by trimming trailing blank lines

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_689f1adc39448327b6bf5efeabbfb483