### PR TITLE
feat: show navigation sidebar on mobile

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,26 +26,28 @@
       <p class="email-img-wrap"><img class="email-img" src="{{ 'email.png' | relative_url }}" alt="aidaraliev(at)gmail.com"></p>
     </aside>
 
-    <!-- Main content -->
-    <main class="content">
-      {{ content }}
-    </main>
+    <div class="main-wrapper">
+      <!-- Main content -->
+      <main class="content">
+        {{ content }}
+      </main>
 
-    <!-- Right sidebar: navigation only -->
-    <aside class="sidebar sidebar-right">
-      <nav class="sidebar-nav" aria-label="Навигация по резюме">
-        <ul>
-          <li><a href="#role">Профиль</a></li>
-          <li><a href="#summary">Абстракт</a></li>
-          <li><a href="#projects">Проекты</a></li>
-          <li><a href="#experience">Опыт работы</a></li>
-          <li><a href="#education">Образование</a></li>
-          <li><a href="#certificates">Сертификаты</a></li>
-          <li><a href="#skills">Навыки</a></li>
-          <li><a href="#about">О себе</a></li>
-        </ul>
-      </nav>
-    </aside>
+      <!-- Right sidebar: navigation only -->
+      <aside class="sidebar sidebar-right">
+        <nav class="sidebar-nav" aria-label="Навигация по резюме">
+          <ul>
+            <li><a href="#role">Профиль</a></li>
+            <li><a href="#summary">Абстракт</a></li>
+            <li><a href="#projects">Проекты</a></li>
+            <li><a href="#experience">Опыт работы</a></li>
+            <li><a href="#education">Образование</a></li>
+            <li><a href="#certificates">Сертификаты</a></li>
+            <li><a href="#skills">Навыки</a></li>
+            <li><a href="#about">О себе</a></li>
+          </ul>
+        </nav>
+      </aside>
+    </div>
   </div>
 </body>
 </html>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -31,6 +31,7 @@ h3{color:var(--accent);margin:2rem 0 1rem;font-size:1.1rem;}
 .job h3{font-size:1.375rem;color:var(--text-main);}
 
 .container{display:flex;gap:32px;max-width:1200px;margin:0 auto;padding:32px;align-items:flex-start;}
+.main-wrapper{display:flex;gap:32px;flex:1;align-items:flex-start;}
 
 /* Shared sidebar styles */
 .sidebar{display:flex;flex-direction:column;align-items:center;gap:var(--sidebar-gap);position:sticky;top:0;height:100vh;padding:24px 0;}
@@ -154,7 +155,8 @@ details.collapsible-details[open] > summary::before{transform:rotate(90deg); col
 @media (max-width: 768px){
   .container{flex-direction:column;gap:24px;padding:16px;}
   .sidebar{position:static;height:auto;width:100%;max-width:none;}
-  .sidebar-left,.sidebar-right{min-width:0;max-width:none;}
-  .content{max-width:none;}
-  .sidebar-right{order:3;}
+  .sidebar-left{min-width:0;max-width:none;}
+  .main-wrapper{display:flex;gap:16px;width:100%;}
+  .content{max-width:none;flex:1;}
+  .sidebar-right{min-width:120px;max-width:180px;width:auto;}
 }


### PR DESCRIPTION
## Summary
- keep navigation sidebar visible on mobile by grouping main content and nav into a flex container
- adjust responsive styles so main content scales next to the right sidebar
- remove generated favicon assets from version control to avoid binary diffs

## Testing
- `bundle exec jekyll build` *(fails: Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered)*
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_689f231ae6e08327847698bde5b90379