### PR TITLE
feat: keep mobile nav visible and center email image

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,26 +26,28 @@
       <p class="email-img-wrap"><img class="email-img" src="{{ 'email.png' | relative_url }}" alt="aidaraliev(at)gmail.com"></p>
     </aside>
 
-    <!-- Main content -->
-    <main class="content">
-      {{ content }}
-    </main>
+    <div class="main-wrapper">
+      <!-- Main content -->
+      <main class="content">
+        {{ content }}
+      </main>
 
-    <!-- Right sidebar: navigation only -->
-    <aside class="sidebar sidebar-right">
-      <nav class="sidebar-nav" aria-label="Навигация по резюме">
-        <ul>
-          <li><a href="#role">Профиль</a></li>
-          <li><a href="#summary">Абстракт</a></li>
-          <li><a href="#projects">Проекты</a></li>
-          <li><a href="#experience">Опыт работы</a></li>
-          <li><a href="#education">Образование</a></li>
-          <li><a href="#certificates">Сертификаты</a></li>
-          <li><a href="#skills">Навыки</a></li>
-          <li><a href="#about">О себе</a></li>
-        </ul>
-      </nav>
-    </aside>
+      <!-- Right sidebar: navigation only -->
+      <aside class="sidebar sidebar-right">
+        <nav class="sidebar-nav" aria-label="Навигация по резюме">
+          <ul>
+            <li><a href="#role">Профиль</a></li>
+            <li><a href="#summary">Абстракт</a></li>
+            <li><a href="#projects">Проекты</a></li>
+            <li><a href="#experience">Опыт работы</a></li>
+            <li><a href="#education">Образование</a></li>
+            <li><a href="#certificates">Сертификаты</a></li>
+            <li><a href="#skills">Навыки</a></li>
+            <li><a href="#about">О себе</a></li>
+          </ul>
+        </nav>
+      </aside>
+    </div>
   </div>
 </body>
 </html>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -18,6 +18,7 @@
 
   /* layout */
   --sidebar-gap:24px; /* base spacing between sidebar items */
+  --mobile-nav-width:150px; /* reserved space for fixed right nav on small screens */
 }
 
 html,body{margin:0;background:var(--bg);color:var(--text-main);font-family:var(--font-body);scroll-behavior:smooth;}
@@ -31,6 +32,7 @@ h3{color:var(--accent);margin:2rem 0 1rem;font-size:1.1rem;}
 .job h3{font-size:1.375rem;color:var(--text-main);}
 
 .container{display:flex;gap:32px;max-width:1200px;margin:0 auto;padding:32px;align-items:flex-start;}
+.main-wrapper{display:flex;gap:32px;flex:1;align-items:flex-start;}
 
 /* Shared sidebar styles */
 .sidebar{display:flex;flex-direction:column;align-items:center;gap:var(--sidebar-gap);position:sticky;top:0;height:100vh;padding:24px 0;}
@@ -53,16 +55,6 @@ h3{color:var(--accent);margin:2rem 0 1rem;font-size:1.1rem;}
 /* add breathing space above and below */
 .sidebar-left .profile-photo{margin-top:8px;margin-bottom:8px;}
 .sidebar-left .qr{margin-top:8px;margin-bottom:8px;border:1px solid var(--cold-dim);border-radius:10px;}
-.sidebar-left .email-img {
-  display: block;
-  max-width: 70%;
-  max-height: 80px; /* или подбери под дизайн */
-  height: auto;
-  opacity: 0.95;
-  margin-left: auto;
-  margin-right: auto;
-}
-.sidebar-left .email-img-wrap{margin-top:-4px;margin-bottom:8px;display:flex;justify-content:center;}
 /* Location and email same size as h2 (Контакты) */
 .sidebar-left .location{font-size:1.25rem;color:var(--white);margin-top:calc(-0.2 * var(--sidebar-gap));}
 
@@ -131,20 +123,20 @@ details.collapsible-details > summary::before{content:'\25BA'; /* ► */ color:v
 details.collapsible-details[open] > summary::before{transform:rotate(90deg); color:var(--warm-dim);}
 /* E-mail image: фиксируем размер и центрируем */
 .email-img-wrap{
-  display:flex;              /* проще всего центрировать */
+  display:flex;              /* центрируем */
   justify-content:center;
-  margin: 8px 0 0;
+  margin:8px 0;
 }
 
 .email-img{
   display:block;
-  max-width: 220px;          /* задай свой максимум (например 180–240px) */
-  width: auto;               /* не растягивать на 100% ширины сайдбара */
-  height:auto;               /* сохранять пропорции */
-  object-fit: contain;
+  max-width:220px;
+  width:auto;
+  height:auto;
+  object-fit:contain;
 }
 
-/* Если где-то есть .sidebar img { width:100%; } — перебиваем точечно */
+/* Перебиваем общие правила сайдбара для почтового изображения */
 .sidebar-left img.email-img{
   width:auto !important;
   max-width:220px !important;
@@ -154,7 +146,17 @@ details.collapsible-details[open] > summary::before{transform:rotate(90deg); col
 @media (max-width: 768px){
   .container{flex-direction:column;gap:24px;padding:16px;}
   .sidebar{position:static;height:auto;width:100%;max-width:none;}
-  .sidebar-left,.sidebar-right{min-width:0;max-width:none;}
-  .content{max-width:none;}
-  .sidebar-right{order:3;}
+  .sidebar-left{min-width:0;max-width:none;}
+  .main-wrapper{display:block;width:100%;}
+  .content{max-width:none;margin-right:var(--mobile-nav-width);}
+  .sidebar-right{
+    position:fixed;
+    top:0;
+    right:0;
+    height:100vh;
+    width:var(--mobile-nav-width);
+    overflow:auto;
+    background:var(--bg);
+    z-index:1000;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap main content and navigation in a `main-wrapper` so the right sidebar remains in the flow
- adjust responsive styles to fix-position the nav on small screens while scaling the main section
- center the email image in the contacts sidebar

## Testing
- `npm --prefix docs run lint:md`
- `bundle exec jekyll build` *(fails: Could not find json-2.13.2, eventmachine-1.2.7, http_parser.rb-0.8.0, io-event-1.11.2, racc-1.8.1, bigdecimal-3.2.2 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_689f231ae6e08327847698bde5b90379