### PR TITLE
Remove deprecated HTMLProofer flag

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Run html-proofer
         run: |
           cd docs
-          htmlproofer ./_site --check-html --assume-extension --disable-external --allow-hash-href
+          htmlproofer ./_site --assume-extension --disable-external --allow-hash-href
 

--- a/docs/.github/workflows/docs-lint.yml
+++ b/docs/.github/workflows/docs-lint.yml
@@ -53,5 +53,5 @@ jobs:
         run: bundle exec jekyll build
 
       - name: Run html-proofer
-        run: bundle exec htmlproofer ./_site --check-html --assume-extension --disable-external --allow-hash-href
+        run: bundle exec htmlproofer ./_site --assume-extension --disable-external --allow-hash-href
 


### PR DESCRIPTION
## Summary
- drop `--check-html` flag from HTMLProofer steps in docs lint workflow

## Testing
- `bundle exec jekyll build`
- `bundle exec htmlproofer ./_site --assume-extension --disable-external --allow-hash-href`
- `npx markdownlint "**/*.md" --ignore node_modules --ignore vendor --ignore _site --config .markdownlint.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a0929b29548327ac8f035fa3d7899c