### PR TITLE
Enable Markdown attributes for PDF

### DIFF
--- a/build_cv.sh
+++ b/build_cv.sh
@@ -21,7 +21,7 @@ pandoc \
     README_processed.md \
     --filter=Pandoc-Emojis-Filter/emoji_filter.js \
     -M emoji=noto-emoji \
-    --from gfm \
+    --from gfm+attributes \
     -V colorlinks \
     -V urlcolor=NavyBlue \
     -V linkcolor=NavyBlue \


### PR DESCRIPTION
## Summary
- enable Pandoc's `attributes` extension so image width hints are honored in the generated CV PDF

## Testing
- `bash -n build_cv.sh`
- `python3 -m py_compile preprocess_readme.py`
- `printf '![](qr.png){width=20%}\n' | pandoc -f gfm+attributes -t latex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0957855608327a56900802863e581